### PR TITLE
Improve get_category_grades

### DIFF
--- a/R/calculate-grades.R
+++ b/R/calculate-grades.R
@@ -59,13 +59,13 @@ weighted_by_points <- function(scores, weights, n_drops = 0, ...) {
 #' @rdname equally_weighted
 #' @export
 max_score <- function(scores, weights, n_drops = 0, ...) {
-    c(max(scores), sum(weights, na.rm = TRUE))
+    c(max(scores, na.rm = TRUE), sum(weights, na.rm = TRUE))
 }
 
 #' @rdname equally_weighted
 #' @export
 min_score <- function(scores, weights, n_drops = 0, ...) {
-    c(min(scores), sum(weights, na.rm = TRUE))
+    c(min(scores, na.rm = TRUE), sum(weights, na.rm = TRUE))
 }
 
 #' @rdname equally_weighted
@@ -120,6 +120,7 @@ get_category_grades <- function(gs, policy) {
     assignment_names <- get_assignments_unprocessed_data(gs, give_alert = FALSE)
     assignment_cols <- c(assignment_names, paste0(assignment_names, " - Max Points"))
     gs_assignments_mat <- data.matrix(gs[assignment_cols])
+    rownames(gs_assignments_mat) <- gs$SID
     if (!is.numeric(gs_assignments_mat)) {stop("Cannot calculate category grades. Assignment columns contain non-numeric values.")}
     
         

--- a/R/calculate-grades.R
+++ b/R/calculate-grades.R
@@ -133,11 +133,15 @@ get_category_grades <- function(gs, policy) {
     
     # for every category in the policy file...
     for (policy_item in policy) {
-        # and for every row in the matrix, get a grade
-        gs[[policy_item$category]] <- apply(gs_assignments_mat, 1, get_one_grade, 
-                                            policy_item = policy_item)
+        # and for every row in the matrix, get a grade and a total weight (max points)
+        grades_weights <- t(apply(gs_assignments_mat, 1,
+                                  get_one_grade, 
+                                  policy_item = policy_item))
+        colnames(grades_weights) <- c(policy_item$category,
+                                      paste0(policy_item$category, " - Max Points"))
+        gs_assignments_mat <- cbind(gs_assignments_mat, grades_weights)
     }
-    gs
+    gs_assignments_mat
 }
 
 #' Drop NA Assignments

--- a/R/calculate-grades.R
+++ b/R/calculate-grades.R
@@ -36,10 +36,10 @@
 #' none(my_score)
 #' 
 #' @export
-equally_weighted <- function(scores, n_drops = 0, ...) {
+equally_weighted <- function(scores, weights, n_drops = 0, ...) {
     if (n_drops > 0) {scores[order(scores)[1:n_drops]] <- NA}
     
-    mean(scores, na.rm =TRUE)
+    c(mean(scores, na.rm =TRUE), sum(weights, na.rm = TRUE))
 }
 
 #' @rdname equally_weighted
@@ -52,27 +52,30 @@ weighted_by_points <- function(scores, weights, n_drops = 0, ...) {
         scores[drop_idx] <- NA
     }
 
-    sum(scores * (weights / sum(weights, na.rm = TRUE)), na.rm =TRUE)
+    c(sum(scores * (weights / sum(weights, na.rm = TRUE)), na.rm =TRUE),
+      sum(weights, na.rm = TRUE))
 }
 
 #' @rdname equally_weighted
 #' @export
-max_score <- function(scores, ...) {
-    max(scores)
+max_score <- function(scores, weights, n_drops = 0, ...) {
+    c(max(scores), sum(weights, na.rm = TRUE))
 }
 
 #' @rdname equally_weighted
 #' @export
-min_score <- function(scores, n_drops = 0, ...) {
-    min(scores)
+min_score <- function(scores, weights, n_drops = 0, ...) {
+    c(min(scores), sum(weights, na.rm = TRUE))
 }
 
 #' @rdname equally_weighted
 #' @export
-none <- function(scores, ...) {
-    ifelse(length(scores) == 1, scores, stop("Can only use `aggregation: none`
-                                             if there is only 1 assignment in 
-                                             the category."))
+none <- function(scores, weights, n_drops = 0, ...) {
+    ifelse(length(scores) == 1, 
+           c(scores, weights),
+           stop("Can only use `aggregation: none`
+                 if there is only 1 assignment in 
+                 the category."))
 }
 
 #' Get one category grade

--- a/R/calculate-grades.R
+++ b/R/calculate-grades.R
@@ -119,10 +119,12 @@ get_category_grades <- function(gs, policy) {
     gs_assignments_mat <- data.matrix(gs[assignment_cols])
     if (!is.numeric(gs_assignments_mat)) {stop("Cannot calculate category grades. Assignment columns contain non-numeric values.")}
     
+        
     # prune unnecessary data from policy file
+    assgns_and_cats <- c(assignment_names, purrr::map(policy, "category"))
     policy <- policy |>
         # remove ungraded assignments
-        purrr::map(\(item) purrr::modify_at(item, "assignments", ~ .x[.x %in% assignment_names])) |>
+        purrr::map(\(item) purrr::modify_at(item, "assignments", ~ .x[.x %in% assgns_and_cats])) |>
         # remove categories with no assignments from policy file
         purrr::discard(\(item) length(item$assignments) == 0)
     


### PR DESCRIPTION
This PR modifies `get_category_grades()` by:

1. Changing the input to `apply()` function to be a numeric matrix instead of data frame that might get coerced in the inner loop.
2. Pruning the policy file before iteration by removing any ungraded assignments and any categories without graded assignments. This both reduces the amount of iteration on the outer (category) loop and speeds up the computation of the inner loop.