### PR TITLE
splitting up validate_policy functionality

### DIFF
--- a/R/calculate-grades.R
+++ b/R/calculate-grades.R
@@ -13,7 +13,8 @@
 get_grades <- function(gs, policy){
   
   # flatten policy file
-  policy <- flatten_policy(policy)
+  policy <- flatten_policy(policy) |>
+    set_defaults(gs) #set defaults
   
   # convert gs into a matrix with only assignment info
   grades_mat <- gs |>

--- a/R/read-gs.R
+++ b/R/read-gs.R
@@ -23,18 +23,6 @@ read_gs <- function(path, drop_ungraded = TRUE, verbose = FALSE){
       drop_ungraded_assignments()
   }
   
-  raw_cols <- get_assignments(gs)
-  
-  gs |>
-    # convert all NA raw-point values into zeros
-    mutate_at(vars(all_of(raw_cols )), ~replace(., is.na(.), 0)) |>
-    # replace raw pts with score
-    mutate(across(raw_cols,
-                  ~ . / get(paste0(cur_column(), " - Max Points")))) |>
-    mutate(across( c(raw_cols, ends_with("Max Points")) , as.numeric ),
-           across( ends_with("Lateness (H:M:S)") , convert_to_min ),
-           across( ends_with("Submission Time") , as.character )
-           )
 }
 
 #' Check Formatting of Gradescope Data

--- a/R/validate-policy.R
+++ b/R/validate-policy.R
@@ -45,7 +45,11 @@ validate_policy <- function(policy, gs, quiet = FALSE){
     } 
     stop("None of the assignments in policy file are found in gs.")
   }
-  
+
+  return (policy)
+}
+
+set_defaults <- function(policy, gs){
   default_cat <- list(
     aggregation = "equally_weighted",
     aggregation_max_pts = "sum_max_pts",
@@ -82,7 +86,7 @@ validate_policy <- function(policy, gs, quiet = FALSE){
     
     return (cat)
   })
-
+  
   return (policy)
 }
 

--- a/tests/testthat/test-validate-policy.R
+++ b/tests/testthat/test-validate-policy.R
@@ -521,11 +521,11 @@ test_that("validate policy - add defaults with equally_weighted/weighted_by_poin
       category = "Quizzes",
       score = "raw_over_max",
       aggregation = "weighted_by_points",
-      assignments = c("Quiz 1", "Quiz 2", "Quiz 3")
+      assignments = c("Quiz 1")
     )
   )
   
-  policy <- list(categories = categories)
+  policy <- list(categories = categories) |> flatten_policy()
   
   gs <- tibble::tibble(
     `SID` = c(3032412514, 3032122516, 3032412516,3032412517),
@@ -566,7 +566,7 @@ test_that("validate policy - add defaults with equally_weighted/weighted_by_poin
     `Quiz 1 - Lateness (H:M:S)` = c("0:00:00","0:00:00","0:00:00","0:00:00")
   )
   
-  actual <- validate_policy(policy, gs)
+  actual <- set_defaults(policy, gs)
   expected_cat <- list(
     list(
       category = "Lab 1",
@@ -629,11 +629,11 @@ test_that("validate policy - add defaults with min_score and max_score",{
       category = "Quizzes",
       score = "raw_over_max",
       aggregation = "weighted_by_points",
-      assignments = c("Quiz 1", "Quiz 2", "Quiz 3")
+      assignments = c("Quiz 1")
     )
   )
   
-  policy <- list(categories = categories)
+  policy <- list(categories = categories) |> flatten_policy()
   
   gs <- tibble::tibble(
     `SID` = c(3032412514, 3032122516, 3032412516,3032412517),
@@ -674,7 +674,7 @@ test_that("validate policy - add defaults with min_score and max_score",{
     `Quiz 1 - Lateness (H:M:S)` = c("0:00:00","0:00:00","0:00:00","0:00:00")
   )
   
-  actual <- validate_policy(policy, gs)
+  actual <- set_defaults(policy, gs)
   expected_cat <- list(
     list(
       category = "Lab 1",
@@ -733,11 +733,11 @@ test_that("validate policy - add score key to categories with gs assignments",{
     list(
       category = "Quizzes",
       aggregation = "weighted_by_points",
-      assignments = c("Quiz 1", "Quiz 2", "Quiz 3")
+      assignments = c("Quiz 1")
     )
   )
   
-  policy <- list(categories = categories)
+  policy <- list(categories = categories) |> flatten_policy()
   
   gs <- tibble::tibble(
     `SID` = c(3032412514, 3032122516, 3032412516,3032412517),
@@ -778,7 +778,7 @@ test_that("validate policy - add score key to categories with gs assignments",{
     `Quiz 1 - Lateness (H:M:S)` = c("0:00:00","0:00:00","0:00:00","0:00:00")
   )
   
-  actual <- validate_policy(policy, gs)
+  actual <- set_defaults(policy, gs)
   expected_cat <- list(
     list(
       category = "Lab 1",


### PR DESCRIPTION
Just a note: I used `flatten_policy()` in some of the tests because that's a function that's always called before `set_defaults`... let me know if I should rewrite the tests to not do so @andrewpbray 
Also, I removed the following functionality in `read_gs()`: calculating raw_pts, setting the types of different cols (converting lateness cols to min) since this is done elsewhere