### PR TITLE
Changes to Find weights + reconcile + new tests

### DIFF
--- a/R/process-policy.R
+++ b/R/process-policy.R
@@ -57,14 +57,7 @@ extract_weights <- function(category){
     }
     
     
-    if (length(category$weights) != length(category$assignments)){
-      warning(paste0("Some sub categories of category ", category$category, 
-                     " are missing a weight value"))
-      category$weights <- c(category$weights, 
-                            rep.int(0, 
-                                    length(category$assignments) - length(category$weights)
-                            ))
-    }
+  
   } 
   
   category$assignments <- purrr::map(category$assignments, extract_weights)

--- a/tests/testthat/test-find-weights.R
+++ b/tests/testthat/test-find-weights.R
@@ -41,7 +41,7 @@ test_that("Extracting Weights", {
   cats2 <- list(list(
     category = "Overall Grade",
     aggregation = "weighted_mean",
-   
+    
     assignments = list(
       list(
         category = "Labs",
@@ -79,4 +79,287 @@ test_that("Extracting Weights", {
   ))
   expected <- list(categories = cats2)
   expect_equal(actual, expected)
+})
+
+test_that("Parallel Grading Trees", {
+  cats <- list(list(
+    category = "Overall Grade Undergrads",
+    aggregation = "weighted_mean",
+    assignments = list(
+      list(
+        category = "Homework",
+        aggregation = "equally_weighted",
+        weight = 0.25,
+        assignments = c("Homework 1", "Homework 2", "HW3", "HW4")
+      ),
+      list(
+        category = "Midterms",
+        aggregation = "weighted_by_points",
+        weight = 0.3,
+        assignments = c("Midterm 1", "Midterm 2", "Midterm 3")
+      ),
+      list(
+        category = "Final",
+        weight = 0.45,
+        assignments = "Final Exam"
+      )
+    )
+  ),
+  list(
+    category = "Overall Grade Grad",
+    aggregation = "weighted_mean",
+    weight = 0.1,
+    assignments = list(
+      list(
+        category = "Homework",
+        aggregation = "equally_weighted",
+        weight = 0.25,
+        assignments = c("Homework 1", "Homework 2", "HW3", "HW4")
+      ),
+      list(
+        category = "Midterms",
+        aggregation = "weighted_by_points",
+        weight = 0.3,
+        assignments = c("Midterm 1", "Midterm 2", "Midterm 3")
+      ),
+      list(
+        category = "Final",
+        weight = 0.45,
+        assignments = "Final Exam"
+      ),
+      list(
+        category = "Final project",
+        weight = 0.8,
+        aggregation = "weighted_mean",
+        assignments = list(
+          list(
+            category = "Coding",
+            weight = -0.2,
+            assigments = "Final project coding"
+          ),
+          list(
+            category = "Report",
+            weight = -0.4,
+            assignments = "Final Report"
+          )
+        )
+      )
+    )
+  ),
+  list(
+    category = "Beep boop",
+    assignments = "Fizz Buzz"
+  ),
+  list(
+    category = "Alt Grades",
+    aggregation = "weighted_mean",
+    assignments = list(
+      list(
+        category = "Exams",
+        aggregation = "weighted_by_points",
+        assignments = c("Final Exam", "Midterm 2"),
+        weight = 0.95
+      ),
+      list(
+        category = "Alt HWs",
+        aggregation = "equally_weighted",
+        weight = 0.05,
+        assignments = c("Homework 2, Homework 7")
+      )
+    )
+  )
+  )
+  pol <- list(categories = cats)
+  
+  exp_cats <- list(list(
+    category = "Overall Grade Undergrads",
+    aggregation = "weighted_mean",
+    assignments = list(
+      list(
+        category = "Homework",
+        aggregation = "equally_weighted",
+        weight = 0.25,
+        assignments = c("Homework 1", "Homework 2", "HW3", "HW4")
+      ),
+      list(
+        category = "Midterms",
+        aggregation = "weighted_by_points",
+        weight = 0.3,
+        assignments = c("Midterm 1", "Midterm 2", "Midterm 3")
+      ),
+      list(
+        category = "Final",
+        weight = 0.45,
+        assignments = "Final Exam"
+      )
+    ),
+    weights = c(0.25, 0.3, 0.45)
+  ),
+  list(
+    category = "Overall Grade Grad",
+    aggregation = "weighted_mean",
+    weight = 0.1,
+    assignments = list(
+      list(
+        category = "Homework",
+        aggregation = "equally_weighted",
+        weight = 0.25,
+        assignments = c("Homework 1", "Homework 2", "HW3", "HW4")
+      ),
+      list(
+        category = "Midterms",
+        aggregation = "weighted_by_points",
+        weight = 0.3,
+        assignments = c("Midterm 1", "Midterm 2", "Midterm 3")
+      ),
+      list(
+        category = "Final",
+        weight = 0.45,
+        assignments = "Final Exam"
+      ),
+      list(
+        category = "Final project",
+        weight = 0.8,
+        aggregation = "weighted_mean",
+        assignments = list(
+          list(
+            category = "Coding",
+            weight = -0.2,
+            assigments = "Final project coding"
+          ),
+          list(
+            category = "Report",
+            weight = -0.4,
+            assignments = "Final Report"
+          )
+        ),
+        weights = c(1/3, 2/3)
+      )
+    ),
+    weights = c(0.25/1.8, 0.3/1.8, 0.45/1.8, 0.8/1.8)
+  ),
+  list(
+    category = "Beep boop",
+    assignments = "Fizz Buzz"
+  ),
+  list(
+    category = "Alt Grades",
+    aggregation = "weighted_mean",
+    assignments = list(
+      list(
+        category = "Exams",
+        aggregation = "weighted_by_points",
+        assignments = c("Final Exam", "Midterm 2"),
+        weight = 0.95
+      ),
+      list(
+        category = "Alt HWs",
+        aggregation = "equally_weighted",
+        weight = 0.05, 
+        assignments = c("Homework 2, Homework 7")
+      )
+    ),
+    weights = c(0.95, 0.05)
+  )
+  )
+  
+  exp <- list(categories = exp_cats)
+  actual <- find_weights(pol)
+  expect_equal(exp, actual)
+})
+
+test_that("If some weighted_mean category has no weights", {
+  cats <- list(
+    list(
+      category = "Overall Grade",
+      aggregation = "weighted_mean",
+      assignments = list(
+        list(
+          category = "Homework",
+          aggregation = "equally_weighted",
+          assignments = c("Homework 1", "Homework 2")
+        ),
+        list(
+          category = "Exams",
+          aggregation = "weighted_by_points",
+          assignments = c("Final", "Midterm")
+        )
+      ), 
+      weights = c(0.5, 0.5)
+    )
+  )
+  pol <- list(categories = cats)
+  act <- find_weights(pol)
+  expect_equal(pol, act)
+})
+
+test_that("Some cats missing weights", {
+  cats <- list(
+    list(
+      category = "Overall Grade",
+      aggregation = "weighted_mean",
+      assignments = list(
+        list(
+          category = "Homework",
+          aggregation = "equally_weighted",
+          weight = 0.15,
+          assignments = c("Homework 1", "Homework 2")
+        ),
+        list(
+          category = "Exams",
+          weight = 0.5,
+          aggregation = "weighted_by_points",
+          assignments = c("Final", "Midterm")
+        ),
+        list(
+          category = "Discussion",
+          aggregation = "weighted_by_points",
+          assignments = c("Discussion 1", "Discussion 2")
+          
+        ),
+        list(
+          category = "Likeable",
+          aggregation = "equally_weighted",
+          assignments = "Likeable points"
+        )
+      )
+    )
+  )
+  
+  pol <- list(categories = cats)
+  cats2 <-  list(
+    list(
+      category = "Overall Grade",
+      aggregation = "weighted_mean",
+      assignments = list(
+        list(
+          category = "Homework",
+          aggregation = "equally_weighted",
+          weight = 0.15,
+          assignments = c("Homework 1", "Homework 2")
+        ),
+        list(
+          category = "Exams",
+          weight = 0.5,
+          aggregation = "weighted_by_points",
+          assignments = c("Final", "Midterm")
+        ),
+        list(
+          category = "Discussion",
+          aggregation = "weighted_by_points",
+          assignments = c("Discussion 1", "Discussion 2")
+          
+        ),
+        list(
+          category = "Likeable",
+          aggregation = "equally_weighted",
+          assignments = "Likeable points"
+        )
+      ),
+      weights = c(0.15/.65, 0.5/.65, 0, 0)
+    )
+  )
+  exp <- list(categories = cats2)
+  actual <- find_weights(pol)
+  expect_equal(exp, actual)
 })


### PR DESCRIPTION
I made find_weights such that it can work with parallel grading trees and converted errors into warnings for when a category is missing a weight. The behavior here is somewhat arbitrary, so we can put our heads together in the future to determine what is the best path. Right now, find_weights imputes missing weights with the following rule:
1. If one category is missing a weight while other categories have them, the category missing the weight gets a weight of 0.
2. If all categories are missing weights, weights are set to be uniform (equivalent to equally weighted behavior). 

I also fixed an oversight in reconcile_policy_with gs that caused tests to fail since weights were not being dropped when categories were. 

I also added several tests for find_weights.

I also added find_weights to the process policy pipeline. 