### PR TITLE
Change grades calculations order

### DIFF
--- a/R/get-grades.R
+++ b/R/get-grades.R
@@ -78,6 +78,9 @@ calculate_grades <- function(gs, policy){
   grades_mat <- cbind(grades_mat, empty)
   
   
+  #compute raw over max --grades are in percentage points (90% is 0.9) instead of raw scores!
+  grades_mat <- raw_over_max(grades_mat, raw_cols)
+  
   # iterate through each policy item
   for (policy_item in policy$categories){
     

--- a/R/process-policy.R
+++ b/R/process-policy.R
@@ -270,15 +270,15 @@ set_defaults <- function(policy, gs, verbose = FALSE){
         cat <- append(cat, default)
       }
     }
-    # if all assignments are in gs (i.e. there are no nested categories)
-    if (!("score" %in% names(cat)) & sum(cat[["assignments"]] %in% get_assignments(gs)) != 0){
-      # default score is raw_over_max
-      score <- list(
-        category = cat[["category"]],
-        score = "raw_over_max")
-      cat[["category"]] <- NULL #to make sure "category" is still first item
-      cat <- append(score, cat)
-    }
+    # # if all assignments are in gs (i.e. there are no nested categories)
+    # if (!("score" %in% names(cat)) & sum(cat[["assignments"]] %in% get_assignments(gs)) != 0){
+    #   # default score is raw_over_max
+    #   score <- list(
+    #     category = cat[["category"]],
+    #     score = "raw_over_max")
+    #   cat[["category"]] <- NULL #to make sure "category" is still first item
+    #   cat <- append(score, cat)
+    # }
     
     return (cat)
   })

--- a/tests/testthat/test-process-policy.R
+++ b/tests/testthat/test-process-policy.R
@@ -867,7 +867,6 @@ test_that("reconcile policy with gs - add score key to categories with gs assign
   expected_cat <- list(
     list(
       category = "Lab 1",
-      score = "raw_over_max",
       aggregation = "max_score",
       assignments = c("Lab 1.1", "Lab 1.2"),
       aggregation_max_pts = "mean_max_pts",
@@ -875,7 +874,6 @@ test_that("reconcile policy with gs - add score key to categories with gs assign
     ),
     list(
       category = "Lab 2",
-      score = "raw_over_max",
       aggregation = "max_score",
       assignments = c("Lab 2.1", "Lab 2.2", "Lab 2.3"),
       aggregation_max_pts = "mean_max_pts",
@@ -890,7 +888,6 @@ test_that("reconcile policy with gs - add score key to categories with gs assign
     ),
     list(
       category = "Quizzes",
-      score = "raw_over_max",
       aggregation = "weighted_by_points",
       assignments = "Quiz 1",
       aggregation_max_pts = "sum_max_pts",


### PR DESCRIPTION
The issue last fall arose from "Final Exam" assignment being in both categories: 'Midterm Clobber" and "Final". Subsequently, after "Midterm Clobber" is calculated, "Final Exam" assignment would get percentage score such that, say a student got 100% on the final, their score will look instead of 56 points out of 56, it would be 100% or 1 in the Final Exam column. Then when we get to the category "Final", the score looks like 1/56, therefore we give the student 0.017 of 1.7% grade.

This happened because we compute on category level these scores and we repeat operations.

 **Now, this new way is the following:**
 
 - make a matrix of all assignments  (as before)
 - compute all raw scores to percentile of ALL assignments on an assignment level (new way)
 - iterate over categories and do aggregation -- this way you do not modify scores and you can use assignments multiple times


**Further work that might be needed:**
- if we need another function, other than `raw_over_max` to compute assignment scores, we will need to modify the package. But for now, we do not have a different use case (perhaps 61A had some different scoring).
